### PR TITLE
[cmd_exec] fix for one dash option

### DIFF
--- a/click_web/resources/cmd_exec.py
+++ b/click_web/resources/cmd_exec.py
@@ -172,8 +172,7 @@ class RequestToCommandArgs:
             # must be called mostly for saving and preparing file output.
             fi.before_script_execute()
 
-            if fi.cmd_opt.startswith('--'):
-                # it's an option
+            if self._is_option(fi.cmd_opt):
                 args.extend(self._process_option(fi))
 
             else:
@@ -198,6 +197,11 @@ class RequestToCommandArgs:
                             logger.info(f'arg_value: "{arg_values}"')
                             args.extend(arg_values)
         return args
+
+    @staticmethod
+    def _is_option(cmd_option):
+        return isinstance(cmd_option, str) and \
+               (cmd_option.startswith('--') or cmd_option.startswith('-'))
 
     def _process_option(self, field_info):
         vals = request.form.getlist(field_info.key)

--- a/tests/test_request_parsing.py
+++ b/tests/test_request_parsing.py
@@ -14,16 +14,18 @@ app = flask.Flask(__name__)
         ({
              '0.0.option.text.1.text.--an-option': 'option-value',
              '0.1.option.text.1.text.--another-option': 'another-option-value',
-             '1.0.option.text.1.text.--option-for-other-command': 'some value'
+             '1.0.option.text.1.text.--option-for-other-command': 'some value',
+             '1.1.option.text.1.text.-short-opt': 'short option value'
          }, (['--an-option', 'option-value', '--another-option', 'another-option-value'],
-             ['--option-for-other-command', 'some value']),
+             ['--option-for-other-command', 'some value', "-short-opt", 'short option value']),
         ), # noqa
         (OrderedDict((
                 ('0.1.option.text.1.text.--another-option', 'another-option-value'),
+                ('1.1.option.text.1.text.-short-opt', 'short option value'),
                 ('0.0.option.text.1.text.--an-option', 'option-value'),
                 ('1.0.option.text.1.text.--option-for-other-command', 'some value')
         )), (['--an-option', 'option-value', '--another-option', 'another-option-value'],
-             ['--option-for-other-command', 'some value']),
+             ['--option-for-other-command', 'some value', "-short-opt", 'short option value']),
         ),
     ])
 def test_form_post_to_commandline_arguments(data, expected):


### PR DESCRIPTION
When having option with one dash, command is not processed properly:
(but one dash is valid option https://click.palletsprojects.com/en/8.0.x/options/#basic-value-options)
e.g
```
@cli.command()
@click.option("-d", "--delay", type=float, default=0.01, help='delay for every line print')
@click.argument("lines", default=10, type=int)
```

```
[2021-07-22 15:54:42,258] INFO in cmd_exec: arg_value: "['-0.99']"
[2021-07-22 15:54:42,258] INFO in cmd_exec: arg_value: "['10']"
127.0.0.1 - - [22/Jul/2021 15:54:42] "POST /cli/print-rows HTTP/1.1" 200 -
[2021-07-22 15:54:42,259] INFO in cmd_exec: Executing: ['/venv/bin/python3', '/a.py', 'print-rows', '-0.99', '10']
```
Option `-d` is and considered as arg_value
Thus output:
```
Usage: a.py print-rows [OPTIONS] [LINES]
Try 'a.py print-rows --help' for help.

Error: no such option: -0
```