### PR TITLE
Allow override of the index template

### DIFF
--- a/click_web/resources/index.py
+++ b/click_web/resources/index.py
@@ -9,7 +9,8 @@ import click_web
 
 def index():
     with click.Context(click_web.click_root_cmd, info_name=click_web.click_root_cmd.name, parent=None) as ctx:
-        return render_template('show_tree.html.j2', ctx=ctx, tree=_click_to_tree(ctx, click_web.click_root_cmd))
+        template_name = click_web._flask_app.config.get("CLICK_WEB_MAIN_TEMPLATE", "show_tree.html.j2")
+        return render_template(template_name, ctx=ctx, tree=_click_to_tree(ctx, click_web.click_root_cmd))
 
 
 def _click_to_tree(ctx: click.Context, node: Union[click.Command, click.MultiCommand], ancestors: list = None):


### PR DESCRIPTION
This small change allow to quickly override the Jinja template by proving your own base template.
If you don't set `app.config["CLICK_WEB_MAIN_TEMPLATE"` there is no changes to the current behaviour of the blueprint

Example folder structure:
> main.py (contain a click app called cli)
> webcli.py (the file bellow)
> webcli/static/custom.css (the css override for the app)
> webcli/templates/my_main_clickweb.html.j2 (A modified version of template show_tree.html.j2)

```python
from click_web import create_click_web_app
from flask import Blueprint
import main

app = create_click_web_app(main, main.cli)
# Expect any custom static and template folder to be located in same folder as this script
# Make custom folder reachable by "custom/static" url path and add templates folder
custom_folder_blueprint = Blueprint(
    "custom", __name__, static_url_path="/static", static_folder="webcli/static", template_folder="webcli/templates"
)
app.register_blueprint(custom_folder_blueprint)

# Set CUSTOM_CSS in flask config so click-web will use it.
app.config["CUSTOM_CSS"] = "custom.css"
app.config["EXPLAIN_TEMPLATE_LOADING"] = True
# Override the main template to one in webcli/templates/my_main_clickweb.html.j2 directory
app.config["CLICK_WEB_MAIN_TEMPLATE"] = "my_main_clickweb.html.j2"`  

if __name__ == "__main__":
    app.run(debug=True, port=5000)
```
