### PR TITLE
feat: handle values passed via envvars

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Util command to run tests and code lint.
 
-pytest && isort . && flake8
+pytest && isort click_web tests && flake8 click_web tests
 retVal=$?
 if [ $retVal -eq 0 ]; then
     echo "All checks OK!"

--- a/click_web/resources/input_fields.py
+++ b/click_web/resources/input_fields.py
@@ -1,3 +1,4 @@
+import os
 import click
 
 from click_web.web_click_types import (EmailParamType, PasswordParamType,
@@ -79,16 +80,37 @@ class BaseInput:
         field = {}
         param = self.param
 
+        def get_default_value():
+            value = param.default
+            # NOTE: click allows setting the envvar value to be just a string or a list of strings
+            # However, there is no documented use of mulitple envvar being used. Only multiple values
+            # being passed to the envvar[1]. So, this function, just parses the first non-empty value for
+            # a list of envvars, and passes the string as-is to the cli in case or multiple-values.
+            #
+            # [1]: https://github.com/pallets/click/blob/5961d31fb566f089ad468a5b26a32f1ebfa7f63e/tests/test_options.py#L214
+            if param.envvar:
+                if isinstance(param.envvar, str) and os.environ.get(param.envvar, None):
+                    value = os.environ[param.envvar]
+                else:
+                    # This pulls the first valid value from the list of envvars
+                    try:
+                        value = next((os.environ[var] for var in param.envvar if os.environ.get(var, None)), value)
+                    except TypeError:
+                        # this must be a sequence, in case it isn't, there would be TypeError
+                        pass
+
+            return value or ''
+
         field['param'] = param.param_type_name
         if param.param_type_name == 'option':
             name = self._to_cmd_line_name(param.opts[0])
-            field['value'] = param.default if param.default else ''
+            field['value'] = get_default_value()
             field['checked'] = 'checked="checked"' if param.default else ''
             field['desc'] = param.help
             field['help'] = param.get_help_record(self.ctx)
         elif param.param_type_name == 'argument':
             name = self._to_cmd_line_name(param.name)
-            field['value'] = param.default
+            field['value'] = get_default_value()
             field['checked'] = ''
             field['help'] = ''
 

--- a/tests/test_click_web.py
+++ b/tests/test_click_web.py
@@ -1,3 +1,4 @@
+import os
 import pprint
 from pathlib import Path
 
@@ -249,4 +250,36 @@ def test_get_custom_input_field_type(ctx, cli, param, expected, command_index):
 
     res = click_web.resources.input_fields.get_input_field(ctx, param, command_index, 0)
     pprint.pprint(res)
+    assert res == expected
+
+
+@pytest.mark.parametrize(
+    'param, envvar, expected',
+    [
+        (click.Argument(["unset", ], envvar="TEST_VAR"), {},
+         {'checked': '',
+          'click_type': 'text',
+          'help': '',
+          'human_readable_name': 'UNSET',
+          'name': '0.0.argument.text.1.text.unset',
+          'nargs': 1,
+          'param': 'argument',
+          'required': True,
+          'type': 'text',
+          'value': None}),
+        (click.Argument(["env-set", ], envvar="TEST_VAR"), {"TEST_VAR": "test-value"},
+         {'checked': '',
+          'click_type': 'text',
+          'help': '',
+          'human_readable_name': 'ENV SET',
+          'name': '0.0.argument.text.1.text.env-set',
+          'nargs': 1,
+          'param': 'argument',
+          'required': True,
+          'type': 'text',
+          'value': "test-value"}),
+    ])
+def test_parse_envvar_for_input_field_values(ctx, cli, param, envvar, expected):
+    os.environ.update(envvar)
+    res = click_web.resources.input_fields.get_input_field(ctx, param, 0, 0)
     assert res == expected

--- a/tests/test_click_web.py
+++ b/tests/test_click_web.py
@@ -278,6 +278,17 @@ def test_get_custom_input_field_type(ctx, cli, param, expected, command_index):
           'required': True,
           'type': 'text',
           'value': "test-value"}),
+        (click.Argument(["env-set", ], envvar=["UNUSED_ENVVAR", "TEST_VAR"]), {"TEST_VAR": "test-value"},
+         {'checked': '',
+          'click_type': 'text',
+          'help': '',
+          'human_readable_name': 'ENV SET',
+          'name': '0.0.argument.text.1.text.env-set',
+          'nargs': 1,
+          'param': 'argument',
+          'required': True,
+          'type': 'text',
+          'value': "test-value"}),
     ])
 def test_parse_envvar_for_input_field_values(ctx, cli, param, envvar, expected):
     os.environ.update(envvar)


### PR DESCRIPTION
### Description

Click [allows setting envvars](https://click.palletsprojects.com/en/stable/advanced/#detecting-the-source-of-a-parameter) to be used as a way to pass values to arguments and options. In such scenarios, the webui doesn't use the values from the environment it's run from.

In this PR, the default values in the forms are parsed and then overridden using the values from environment variables.